### PR TITLE
Configure dependabot to update github actions in workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,3 +49,11 @@ updates:
     assignees:
       - "ehonda"
     open-pull-requests-limit: 5
+
+  - directory: "/.github/workflows"
+    package-ecosystem: "github-actions"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "ehonda"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Configure dependabot to update github actions in workflows, so we keep those up to date as well.