### PR TITLE
Experiment: Simplify dependabot config for nuget

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,48 +1,6 @@
 version: 2
 updates:
-  # We can't use yaml anchors (or another way to reuse the common configuration), so there's some repetetiveness to the
-  # array elements provided here, as (right now) we just want the same config, but for every .csproj in the project.
-  - directory: "/src/TestUtilities.Scenarios"
-    package-ecosystem: "nuget"
-    schedule:
-      interval: "daily"
-    assignees:
-      - "ehonda"
-    open-pull-requests-limit: 5
-
-  - directory: "/tests/TestUtilities.Scenarios.Tests"
-    package-ecosystem: "nuget"
-    schedule:
-      interval: "daily"
-    assignees:
-      - "ehonda"
-    open-pull-requests-limit: 5
-
-  - directory: "/samples/Examples/Examples.Common"
-    package-ecosystem: "nuget"
-    schedule:
-      interval: "daily"
-    assignees:
-      - "ehonda"
-    open-pull-requests-limit: 5
-
-  - directory: "/samples/Examples/Examples.MSTest"
-    package-ecosystem: "nuget"
-    schedule:
-      interval: "daily"
-    assignees:
-      - "ehonda"
-    open-pull-requests-limit: 5
-
-  - directory: "/samples/Examples/Examples.NUnit"
-    package-ecosystem: "nuget"
-    schedule:
-      interval: "daily"
-    assignees:
-      - "ehonda"
-    open-pull-requests-limit: 5
-
-  - directory: "/samples/Examples/Examples.XUnit"
+  - directory: "/"
     package-ecosystem: "nuget"
     schedule:
       interval: "daily"


### PR DESCRIPTION
It's not clear if this will work, but we'll try setting the `directory` to `/` for `nuget`.

It's not really clear from the [documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directory) what it should be, but it works e.g. for [Mapperly](https://github.com/riok/mapperly/blob/a8acc04af274b726231a7bf6814dfa9dc2d29002/.github/dependabot.yml#L8-L11). The difference is that they have a `Directory.build.props` in the directory root, maybe that is needed as well for this to work.