### PR TITLE
Revert simplified configuration and fix sample paths

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,48 @@
 version: 2
 updates:
-  - directory: "/"
+  # We can't use yaml anchors (or another way to reuse the common configuration), so there's some repetetiveness to the
+  # array elements provided here, as (right now) we just want the same config, but for every .csproj in the project.
+  - directory: "/src/TestUtilities.Scenarios"
+    package-ecosystem: "nuget"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "ehonda"
+    open-pull-requests-limit: 5
+
+  - directory: "/tests/TestUtilities.Scenarios.Tests"
+    package-ecosystem: "nuget"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "ehonda"
+    open-pull-requests-limit: 5
+
+  - directory: "/samples/Examples.Common"
+    package-ecosystem: "nuget"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "ehonda"
+    open-pull-requests-limit: 5
+
+  - directory: "/samples/Examples.MSTest"
+    package-ecosystem: "nuget"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "ehonda"
+    open-pull-requests-limit: 5
+
+  - directory: "/samples/Examples.NUnit"
+    package-ecosystem: "nuget"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "ehonda"
+    open-pull-requests-limit: 5
+
+  - directory: "/samples/Examples.XUnit"
     package-ecosystem: "nuget"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Reverts the experiment from #96 , as it did not work (we probably need a `Directory.build.props` in the root for that), and fixes the paths for the exmple projects (which were broken before)