### PR TITLE
Fix paths for README and icon

### DIFF
--- a/src/TestUtilities.Scenarios/TestUtilities.Scenarios.csproj
+++ b/src/TestUtilities.Scenarios/TestUtilities.Scenarios.csproj
@@ -38,8 +38,8 @@
 
     <!-- Pack readme file and icon -->
     <ItemGroup>
-        <None Include="..\README.md" Pack="true" PackagePath="\" />
-        <None Include="..\Relaxdays.png" Pack="true" PackagePath="\" />
+        <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+        <None Include="..\..\Relaxdays.png" Pack="true" PackagePath="\" />
     </ItemGroup>
 
     <!-- SourceLink -->


### PR DESCRIPTION
Fix the paths for the `README` and Relaxdays icon in the main `.csproj` that broke due to the restructuring of the repo files.